### PR TITLE
Reclassify .shader files as C# files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.shader linguist-language=C#


### PR DESCRIPTION
This is so that huge amount of .shader files aren't counted for the code statistics and we get a shiny green C# circle instead of a stupid white ShaderLab one.